### PR TITLE
Use read buffer for `Socket`

### DIFF
--- a/uring/src/main/scala/fs2/io/uring/Uring.scala
+++ b/uring/src/main/scala/fs2/io/uring/Uring.scala
@@ -19,6 +19,7 @@ package fs2.io.uring
 import cats.effect.kernel.Async
 import cats.effect.kernel.Cont
 import cats.effect.kernel.MonadCancel
+import cats.effect.kernel.Resource
 import cats.syntax.all._
 import cats.~>
 import fs2.io.uring.unsafe.UringExecutorScheduler
@@ -26,7 +27,6 @@ import fs2.io.uring.unsafe.uring._
 import fs2.io.uring.unsafe.uringOps._
 
 import scala.scalanative.unsafe.Ptr
-import cats.effect.kernel.Resource
 
 private[uring] final class Uring[F[_]](ring: UringExecutorScheduler)(implicit F: Async[F]) {
 

--- a/uring/src/main/scala/fs2/io/uring/net/ResizableBuffer.scala
+++ b/uring/src/main/scala/fs2/io/uring/net/ResizableBuffer.scala
@@ -37,7 +37,7 @@ private[net] final class ResizableBuffer[F[_]] private (
       ptr = realloc(ptr, size.toUInt)
       this.size = size
       if (ptr == null)
-        F.raiseError(new RuntimeException(s"realloc: ${errno}"))
+        F.raiseError[Ptr[Byte]](new RuntimeException(s"realloc: ${errno}"))
       else F.pure(ptr)
     }
   }.flatten

--- a/uring/src/main/scala/fs2/io/uring/net/ResizableBuffer.scala
+++ b/uring/src/main/scala/fs2/io/uring/net/ResizableBuffer.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Arman Bilge
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.io.uring.net
+
+import cats.effect.kernel.Resource
+import cats.effect.kernel.Sync
+import cats.syntax.all._
+
+import scala.scalanative.libc.errno._
+import scala.scalanative.libc.stdlib._
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+
+private[net] final class ResizableBuffer[F[_]] private (
+    private var ptr: Ptr[Byte],
+    private[this] var size: Int
+)(implicit F: Sync[F]) {
+
+  def get(size: Int): F[Ptr[Byte]] = F.delay {
+    if (size <= this.size)
+      F.pure(ptr)
+    else {
+      ptr = realloc(ptr, size.toUInt)
+      this.size = size
+      if (ptr == null)
+        F.raiseError(new RuntimeException(s"realloc: ${errno}"))
+      else F.pure(ptr)
+    }
+  }.flatten
+
+}
+
+private[net] object ResizableBuffer {
+
+  def apply[F[_]](size: Int)(implicit F: Sync[F]): Resource[F, ResizableBuffer[F]] =
+    Resource.make {
+      F.delay {
+        val ptr = malloc(size.toUInt)
+        if (ptr == null)
+          throw new RuntimeException(s"malloc: ${errno}")
+        else new ResizableBuffer(ptr, size)
+      }
+    }(buf => F.delay(free(buf.ptr)))
+
+}

--- a/uring/src/main/scala/fs2/io/uring/net/UringSocket.scala
+++ b/uring/src/main/scala/fs2/io/uring/net/UringSocket.scala
@@ -65,7 +65,7 @@ private[net] final class UringSocket[F[_]](
         buf <- buffer.get(numBytes)
         bytes <- F.delay(new Array[Byte](numBytes))
         readed <- recv(buf, numBytes, MSG_WAITALL)
-      } yield Chunk.array(toArray(buf, readed))
+      } yield if (readed > 0) Chunk.array(toArray(buf, readed)) else Chunk.empty
     }
 
   def reads: Stream[F, Byte] = Stream.repeatEval(read(defaultReadSize)).unNoneTerminate.unchunks

--- a/uring/src/main/scala/fs2/io/uring/net/UringSocket.scala
+++ b/uring/src/main/scala/fs2/io/uring/net/UringSocket.scala
@@ -63,7 +63,6 @@ private[net] final class UringSocket[F[_]](
     readSemaphore.permit.surround {
       for {
         buf <- buffer.get(numBytes)
-        bytes <- F.delay(new Array[Byte](numBytes))
         readed <- recv(buf, numBytes, MSG_WAITALL)
       } yield if (readed > 0) Chunk.array(toArray(buf, readed)) else Chunk.empty
     }

--- a/uring/src/main/scala/fs2/io/uring/net/UringSocketGroup.scala
+++ b/uring/src/main/scala/fs2/io/uring/net/UringSocketGroup.scala
@@ -39,13 +39,13 @@ private final class UringSocketGroup[F[_]](implicit F: Async[F], dns: Dns[F])
   def client(to: SocketAddress[Host], options: List[SocketOption]): Resource[F, Socket[F]] =
     Resource.eval(Uring[F]).flatMap { implicit ring =>
       Resource.eval(to.resolve).flatMap { address =>
-        openSocket(address.host.isInstanceOf[Ipv4Address]).evalMap { fd =>
-          SocketAddressHelpers.allocateSockaddr.use { case (addr, len) =>
-            F.delay(SocketAddressHelpers.toSockaddr(address, addr, len)) *>
-              ring(io_uring_prep_connect(_, fd, addr, !len)) *>
-              UringSocket(ring, fd, address)
-          }
-
+        openSocket(address.host.isInstanceOf[Ipv4Address]).flatMap { fd =>
+          Resource.eval {
+            SocketAddressHelpers.allocateSockaddr.use { case (addr, len) =>
+              F.delay(SocketAddressHelpers.toSockaddr(address, addr, len)) *>
+                ring(io_uring_prep_connect(_, fd, addr, !len))
+            }
+          } *> UringSocket(ring, fd, address)
         }
       }
     }
@@ -91,24 +91,27 @@ private final class UringSocketGroup[F[_]](implicit F: Async[F], dns: Dns[F])
         sockets = Stream
           .resource(SocketAddressHelpers.allocateSockaddr)
           .flatMap { case (addr, len) =>
-            Stream.repeatEval {
-              val acceptF =
-                F.delay(!len = sizeof[sockaddr_in6].toUInt) *>
-                  ring(io_uring_prep_accept(_, fd, addr, len, 0))
+            Stream.resource {
+              val accept = Resource.makeFull[F, Int] { poll =>
+                poll(
+                  F.delay(!len = sizeof[sockaddr_in6].toUInt) *>
+                    ring(io_uring_prep_accept(_, fd, addr, len, 0))
+                )
+              }(closeSocket(_))
 
               val convert =
                 F.delay(SocketAddressHelpers.toSocketAddress(addr))
                   .flatMap(_.liftTo)
 
-              acceptF
+              accept
                 .flatMap { clientFd =>
-                  convert.flatMap { remoteAddress =>
+                  Resource.eval(convert).flatMap { remoteAddress =>
                     UringSocket(ring, clientFd, remoteAddress)
                   }
                 }
                 .attempt
                 .map(_.toOption)
-            }
+            }.repeat
           }
 
       } yield (localAddress, sockets.unNone)
@@ -118,9 +121,10 @@ private final class UringSocketGroup[F[_]](implicit F: Async[F], dns: Dns[F])
     Resource.make[F, Int] {
       val domain = if (ipv4) AF_INET else AF_INET6
       F.delay(socket(domain, SOCK_STREAM, 0))
-    } { fd =>
-      ring(io_uring_prep_close(_, fd)).void
-    }
+    }(closeSocket(_))
+
+  private def closeSocket(fd: Int)(implicit ring: Uring[F]): F[Unit] =
+    ring(io_uring_prep_close(_, fd)).void
 
 }
 

--- a/uring/src/main/scala/fs2/io/uring/unsafe/util.scala
+++ b/uring/src/main/scala/fs2/io/uring/unsafe/util.scala
@@ -16,12 +16,20 @@
 
 package fs2.io.uring.unsafe
 
-import scala.scalanative.unsafe._
+import scala.scalanative.libc.string._
 import scala.scalanative.runtime.ByteArray
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
 
 private[uring] object util {
 
   def toPtr(bytes: Array[Byte]): Ptr[Byte] =
     bytes.asInstanceOf[ByteArray].at(0)
+
+  def toArray(ptr: Ptr[Byte], length: Int): Array[Byte] = {
+    val bytes = new Array[Byte](length)
+    memcpy(toPtr(bytes), ptr, length.toUInt)
+    bytes
+  }
 
 }

--- a/uring/src/test/scala/fs2/io/uring/UringRuntimeSuite.scala
+++ b/uring/src/test/scala/fs2/io/uring/UringRuntimeSuite.scala
@@ -50,7 +50,7 @@ class UringRuntimeSuite extends UringSuite {
   test("submission") {
     Uring[IO]
       .flatMap { ring =>
-        ring(io_uring_prep_nop(_))
+        ring.call(io_uring_prep_nop(_))
       }
       .assertEquals(0)
   }

--- a/uring/src/test/scala/fs2/io/uring/net/TcpSocketSuite.scala
+++ b/uring/src/test/scala/fs2/io/uring/net/TcpSocketSuite.scala
@@ -212,4 +212,10 @@ class TcpSocketSuite extends UringSuite {
     }
   }
 
+  test("accept is cancelable") {
+    sg.serverResource().use { case (_, clients) =>
+      clients.compile.drain.timeoutTo(100.millis, IO.unit)
+    }
+  }
+
 }


### PR DESCRIPTION
Benchmarks revealed my foolishness in repeatedly allocating large arrays on the GC for every read, even if only a fraction of the bytes requested were actually read. So now we use the FS2-inspired pattern by reading into a buffer and copying the actual number of bytes read into a new, appropriately-sized array.

While working on this, I realized that accepted sockets were not being closed, so I fixed that.

This also pointed me to another issue I was familiar with: if cancellation of an io_uring op is attempted, but it didn't actually cancel, then any resource it acquired (such as a socket fd via an `accept` op) would be leaked. So now a special `ring.bracket` op correctly handles this case (and `ring.apply` was renamed to `.call` as in sys call).