### PR TITLE
Fix use of `io_uring_submit_and_wait_timeout`

### DIFF
--- a/uring/src/main/scala/fs2/io/uring/unsafe/UringExecutorScheduler.scala
+++ b/uring/src/main/scala/fs2/io/uring/unsafe/UringExecutorScheduler.scala
@@ -75,7 +75,7 @@ private[uring] final class UringExecutorScheduler(
 
         val cqe = stackalloc[Ptr[io_uring_cqe]]()
         if (pendingSubmissions) {
-          io_uring_submit_and_wait_timeout(ring, cqe, 1.toUInt, timeoutSpec, null)
+          io_uring_submit_and_wait_timeout(ring, cqe, 0.toUInt, timeoutSpec, null)
         } else {
           io_uring_wait_cqe_timeout(ring, cqe, timeoutSpec)
         }


### PR DESCRIPTION
Fixes a regression due to https://github.com/armanbilge/fs2-io_uring/pull/13 which was causing timeouts to take double what they were supposed to.

I don't entirely understand why, but seems related to https://github.com/axboe/liburing/issues/232. In any case passing a `0` seems to disable the weird behavior which is good enough for me.