### PR TITLE
Set `NONBLOCK`

### DIFF
--- a/uring/src/main/scala/fs2/io/uring/unsafe/syssocket.scala
+++ b/uring/src/main/scala/fs2/io/uring/unsafe/syssocket.scala
@@ -21,6 +21,8 @@ import scala.scalanative.unsafe._
 
 @extern
 private[uring] object syssocket {
+  final val SOCK_NONBLOCK = 2048
+
   def bind(sockfd: CInt, addr: Ptr[sockaddr], addrlen: socklen_t): CInt =
     extern
 }


### PR DESCRIPTION
I can't tell if this makes a difference 🤔 but the liburing tests use it and it doesn't seem to hurt.

I was hoping this was related to https://github.com/armanbilge/fs2-io_uring/issues/56 but it doesn't seem to be the case.