### PR TITLE
Revert "Set `NONBLOCK`"

### DIFF
--- a/uring/src/main/scala/fs2/io/uring/net/UringSocketGroup.scala
+++ b/uring/src/main/scala/fs2/io/uring/net/UringSocketGroup.scala
@@ -27,7 +27,6 @@ import fs2.io.net.Socket
 import fs2.io.net.SocketGroup
 import fs2.io.net.SocketOption
 import fs2.io.uring.unsafe.netinetin._
-import fs2.io.uring.unsafe.syssocket.SOCK_NONBLOCK
 import fs2.io.uring.unsafe.uring._
 
 import scala.scalanative.libc.errno._
@@ -94,7 +93,7 @@ private final class UringSocketGroup[F[_]](implicit F: Async[F], dns: Dns[F])
           .flatMap { case (addr, len) =>
             Stream.resource {
               val accept = Resource.eval(F.delay(!len = sizeof[sockaddr_in6].toUInt)) *>
-                ring.bracket(io_uring_prep_accept(_, fd, addr, len, SOCK_NONBLOCK))(closeSocket(_))
+                ring.bracket(io_uring_prep_accept(_, fd, addr, len, 0))(closeSocket(_))
 
               val convert =
                 F.delay(SocketAddressHelpers.toSocketAddress(addr))
@@ -117,7 +116,7 @@ private final class UringSocketGroup[F[_]](implicit F: Async[F], dns: Dns[F])
   private def openSocket(ipv4: Boolean)(implicit ring: Uring[F]): Resource[F, Int] =
     Resource.make[F, Int] {
       val domain = if (ipv4) AF_INET else AF_INET6
-      F.delay(socket(domain, SOCK_STREAM | SOCK_NONBLOCK, 0))
+      F.delay(socket(domain, SOCK_STREAM, 0))
     }(closeSocket(_))
 
   private def closeSocket(fd: Int)(implicit ring: Uring[F]): F[Unit] =

--- a/uring/src/main/scala/fs2/io/uring/net/unixsocket/UringUnixSockets.scala
+++ b/uring/src/main/scala/fs2/io/uring/net/unixsocket/UringUnixSockets.scala
@@ -88,8 +88,7 @@ private[net] final class UringUnixSockets[F[_]: Files](implicit F: Async[F])
 
         socket <- Stream
           .resource {
-            val accept =
-              ring.bracket(io_uring_prep_accept(_, fd, null, null, SOCK_NONBLOCK))(closeSocket(_))
+            val accept = ring.bracket(io_uring_prep_accept(_, fd, null, null, 0))(closeSocket(_))
             accept
               .flatMap(UringSocket(ring, _, null))
               .attempt
@@ -118,7 +117,7 @@ private[net] final class UringUnixSockets[F[_]: Files](implicit F: Async[F])
 
   private def openSocket(implicit ring: Uring[F]): Resource[F, Int] =
     Resource.make[F, Int] {
-      F.delay(socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0))
+      F.delay(socket(AF_UNIX, SOCK_STREAM, 0))
     }(closeSocket(_))
 
   private def closeSocket(fd: Int)(implicit ring: Uring[F]): F[Unit] =

--- a/uring/src/main/scala/fs2/io/uring/unsafe/syssocket.scala
+++ b/uring/src/main/scala/fs2/io/uring/unsafe/syssocket.scala
@@ -21,8 +21,6 @@ import scala.scalanative.unsafe._
 
 @extern
 private[uring] object syssocket {
-  final val SOCK_NONBLOCK = 2048
-
   def bind(sockfd: CInt, addr: Ptr[sockaddr], addrlen: socklen_t): CInt =
     extern
 }


### PR DESCRIPTION
This reverts commit #57, f74a9ccc10e9df4c3ddba8694ee2c2f228c3c5eb.

It did make a difference. Canceling an in-flight `accept` started raising an annoying unhandled error.

```
java.io.IOException: 11
        at java.lang.StackTrace$.$anonfun$currentStackTrace$1(Unknown Source)
        at java.lang.StackTrace$$$Lambda$2.apply(Unknown Source)
        at scala.scalanative.unsafe.Zone$.apply(Unknown Source)
        at java.lang.StackTrace$.currentStackTrace(Unknown Source)
        at java.lang.Throwable.fillInStackTrace(Unknown Source)
        at fs2.io.uring.IOExceptionHelper$.apply(Unknown Source)
        at fs2.io.uring.Uring$$anon$1.$anonfun$apply$7(Unknown Source)
        at fs2.io.uring.Uring$$anon$1$$Lambda$2.apply(Unknown Source)
        at flatMap @ fs2.io.uring.Uring$$anon$1.$anonfun$apply$6(Unknown Source)
        at async_ @ fs2.io.uring.Uring.fs2$io$uring$Uring$$cancel(Unknown Source)
        at map @ fs2.io.uring.Uring.fs2$io$uring$Uring$$cancel(Unknown Source)
        at ifM$extension @ fs2.io.uring.Uring$$anon$1.$anonfun$apply$4(Unknown Source)
        at delay @ fs2.io.uring.Uring$$anon$1.$anonfun$apply$2(Unknown Source)
        at flatMap @ fs2.io.uring.Uring$$anon$1.$anonfun$apply$2(Unknown Source)
        at flatTap @ fs2.io.uring.Uring$$anon$1.$anonfun$apply$2(Unknown Source)
        at uncancelable @ fs2.io.uring.Uring$$anon$1.$anonfun$apply$1(Unknown Source)
        at cont @ fs2.io.uring.Uring.exec(Unknown Source)
```

As I continued investigating in https://github.com/armanbilge/fs2-io_uring/issues/56 I felt less sure about this change.