### PR TITLE
Poll for readiness before reading/writing sockets

### DIFF
--- a/uring/src/main/resources/scala-native/uring.c
+++ b/uring/src/main/resources/scala-native/uring.c
@@ -4,6 +4,10 @@ struct io_uring_sqe *fs2_io_uring_get_sqe(struct io_uring *ring) {
   return io_uring_get_sqe(ring);
 }
 
+void fs2_io_uring_sqe_set_flags(struct io_uring_sqe *sqe, unsigned flags) {
+  io_uring_sqe_set_flags(sqe, flags);
+}
+
 void fs2_io_uring_cq_advance(struct io_uring *ring, unsigned nr) {
   io_uring_cq_advance(ring, nr);
 }
@@ -28,6 +32,11 @@ void fs2_io_uring_prep_close(struct io_uring_sqe *sqe, int fd) {
 void fs2_io_uring_prep_connect(struct io_uring_sqe *sqe, int fd,
                                const struct sockaddr *addr, socklen_t addrlen) {
   io_uring_prep_connect(sqe, fd, addr, addrlen);
+}
+
+void fs2_io_uring_prep_poll_add(struct io_uring_sqe *sqe, int fd,
+                                unsigned int pollmask) {
+  io_uring_prep_poll_add(sqe, fd, pollmask);
 }
 
 void fs2_io_uring_prep_recv(struct io_uring_sqe *sqe, int sockfd, void *buf,

--- a/uring/src/main/scala/fs2/io/uring/IOExceptionHelper.scala
+++ b/uring/src/main/scala/fs2/io/uring/IOExceptionHelper.scala
@@ -19,6 +19,8 @@ package fs2.io.uring
 import java.io.IOException
 import java.net.ConnectException
 import java.net.BindException
+import scala.scalanative.libc.string._
+import scala.scalanative.unsafe._
 
 private[uring] object IOExceptionHelper {
 
@@ -29,7 +31,7 @@ private[uring] object IOExceptionHelper {
       new BindException("Cannot assign requested address")
     case 111 => // ECONNREFUSED
       new ConnectException("Connection refused")
-    case _ => new IOException(errno.toString)
+    case _ => new IOException(fromCString(strerror(errno)))
   }
 
 }

--- a/uring/src/main/scala/fs2/io/uring/Uring.scala
+++ b/uring/src/main/scala/fs2/io/uring/Uring.scala
@@ -52,7 +52,9 @@ private[uring] final class Uring[F[_]](ring: UringExecutorScheduler)(implicit F:
       prep: (Ptr[io_uring_sqe], Ptr[io_uring_sqe]) => Unit
   )(release: Int => F[Unit]): F[Int] =
     submit { resume =>
-      val sqe1 = ring.getSqe(null)
+      val sqe1 = ring.getSqe { result =>
+        if (result.isLeft) resume(result) else ()
+      }
       val sqe2 = ring.getSqe(resume)
       prep(sqe1, sqe2)
       sqe1 // cancel via first sqe

--- a/uring/src/main/scala/fs2/io/uring/unsafe/UringExecutorScheduler.scala
+++ b/uring/src/main/scala/fs2/io/uring/unsafe/UringExecutorScheduler.scala
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-package fs2.io.uring.unsafe
+package fs2.io.uring
+package unsafe
 
 import cats.effect.unsafe.PollingExecutorScheduler
 
@@ -42,10 +43,8 @@ private[uring] final class UringExecutorScheduler(
   def getSqe(cb: Either[Throwable, Int] => Unit): Ptr[io_uring_sqe] = {
     pendingSubmissions = true
     val sqe = io_uring_get_sqe(ring)
-    if (cb ne null) {
-      io_uring_sqe_set_data(sqe, cb)
-      callbacks.add(cb)
-    }
+    io_uring_sqe_set_data(sqe, cb)
+    callbacks.add(cb)
     sqe
   }
 
@@ -111,10 +110,8 @@ private[uring] final class UringExecutorScheduler(
       val cqe = !cqes
 
       val cb = io_uring_cqe_get_data[Either[Exception, Int] => Unit](cqe)
-      if (cb ne null) {
-        cb(Right(cqe.res))
-        callbacks.remove(cb)
-      }
+      cb(Right(cqe.res))
+      callbacks.remove(cb)
 
       i += 1
       cqes += 1

--- a/uring/src/main/scala/fs2/io/uring/unsafe/uring.scala
+++ b/uring/src/main/scala/fs2/io/uring/unsafe/uring.scala
@@ -25,6 +25,8 @@ import scala.scalanative.runtime.Intrinsics._
 
 @extern
 private[uring] object uring {
+  final val IOSQE_IO_LINK = 1 << 2
+
   type __u8 = CUnsignedChar
   type __u16 = CUnsignedShort
   type __s32 = CInt
@@ -103,6 +105,9 @@ private[uring] object uring {
   @name("fs2_io_uring_get_sqe")
   def io_uring_get_sqe(ring: Ptr[io_uring]): Ptr[io_uring_sqe] = extern
 
+  @name("fs2_io_uring_sqe_set_flags")
+  def io_uring_sqe_set_flags(sqe: Ptr[io_uring_sqe], flags: CUnsignedInt): Unit = extern
+
   def io_uring_submit(ring: Ptr[io_uring]): CInt = extern
 
   def io_uring_submit_and_wait_timeout(
@@ -152,6 +157,13 @@ private[uring] object uring {
       fd: CInt,
       addr: Ptr[sockaddr],
       addrlen: socklen_t
+  ): Unit = extern
+
+  @name("fs2_io_uring_prep_poll_add")
+  def io_uring_prep_poll_add(
+      sqe: Ptr[io_uring_sqe],
+      fd: CInt,
+      pollmask: CUnsignedInt
   ): Unit = extern
 
   @name("fs2_io_uring_prep_recv")


### PR DESCRIPTION
I think this closes https://github.com/armanbilge/fs2-io_uring/issues/56.

The idea here is to poll the socket for readiness before doing the actual read/write. To avoid having to make two separate submissions, this is achieved via SQE "linking": the polling SQE links to the read/write SQE as its "next step".

Manually testing against the reproducer in https://github.com/armanbilge/fs2-io_uring/issues/56 I can no longer see the `iou-wrk` threads. So that seems good.

I don't _really_ understand why this fixed things. I also need to figure out if I want to do this for `accept` and `connect`.