### PR TITLE
Replace `Semaphore` with `Mutex`

### DIFF
--- a/uring/src/main/scala/fs2/io/uring/net/UringSocket.scala
+++ b/uring/src/main/scala/fs2/io/uring/net/UringSocket.scala
@@ -80,7 +80,8 @@ private[net] final class UringSocket[F[_]](
   def localAddress: F[SocketAddress[IpAddress]] = UringSocket.getLocalAddress(fd)
 
   def write(bytes: Chunk[Byte]): F[Unit] =
-    writeMutex.lock.surround {
+    writeMutex.lock
+      .surround {
         val slice = bytes.toArraySlice
         val ptr = slice.values.at(0) + slice.offset.toLong
         ring

--- a/uring/src/main/scala/fs2/io/uring/net/UringSocket.scala
+++ b/uring/src/main/scala/fs2/io/uring/net/UringSocket.scala
@@ -22,7 +22,6 @@ package net
 import cats.effect.kernel.Async
 import cats.effect.kernel.Resource
 import cats.effect.kernel.Sync
-import cats.effect.std.Semaphore
 import cats.effect.std.Mutex
 import cats.syntax.all._
 import com.comcast.ip4s.IpAddress


### PR DESCRIPTION
Updates the UringSocket implementation to use Mutex instead of Semaphore(1) following the changes introduced in Cats Effect 3.5.x.